### PR TITLE
Dask Integration Documentation for Hugging Face Hub

### DIFF
--- a/docs/hub/datasets-dask.md
+++ b/docs/hub/datasets-dask.md
@@ -1,47 +1,62 @@
-# Dask
+# Dask Integration with Hugging Face
 
-[Dask](https://github.com/dask/dask) is a parallel and distributed computing library that scales the existing Python and PyData ecosystem.
-Since it uses [fsspec](https://filesystem-spec.readthedocs.io) to read and write remote data, you can use the Hugging Face paths ([`hf://`](/docs/huggingface_hub/guides/hf_file_system#integrations)) to read and write data on the Hub:
+[Dask](https://github.com/dask/dask) is a powerful parallel and distributed computing library that scales the existing Python and PyData ecosystem. By leveraging [fsspec](https://filesystem-spec.readthedocs.io/en/latest/), Dask can seamlessly interact with remote data sources, including the Hugging Face Hub. This allows you to read and write datasets directly from the Hub using Hugging Face paths (`hf://`).
 
-First you need to [Login with your Hugging Face account](/docs/huggingface_hub/quick-start#login), for example using:
+## Prerequisites
 
-```
-huggingface-cli login
-```
+Before you can use Hugging Face paths with Dask, you need to:
 
-Then you can [Create a dataset repository](/docs/huggingface_hub/quick-start#create-a-repository), for example using:
+1. **Login to your Hugging Face account:**  
+   Authenticate your session by logging in using the Hugging Face CLI:
+   ```bash
+   huggingface-cli login
+   ```
 
-```python
-from huggingface_hub import HfApi
+2. **Create a dataset repository:**  
+   You can create a new dataset repository on the Hugging Face Hub using the `HfApi` class:
+   ```python
+   from huggingface_hub import HfApi
 
-HfApi().create_repo(repo_id="username/my_dataset", repo_type="dataset")
-```
+   HfApi().create_repo(repo_id="username/my_dataset", repo_type="dataset")
+   ```
 
-Finally, you can use [Hugging Face paths](/docs/huggingface_hub/guides/hf_file_system#integrations) in Dask:
+## Writing Data to the Hub
+
+Once your environment is set up, you can easily write Dask DataFrames to the Hugging Face Hub. For instance, to store your dataset in Parquet format:
 
 ```python
 import dask.dataframe as dd
 
+# Writing the entire dataset to a single location
 df.to_parquet("hf://datasets/username/my_dataset")
 
-# or write in separate directories if the dataset has train/validation/test splits
+# Writing data to separate directories for train/validation/test splits
 df_train.to_parquet("hf://datasets/username/my_dataset/train")
 df_valid.to_parquet("hf://datasets/username/my_dataset/validation")
-df_test .to_parquet("hf://datasets/username/my_dataset/test")
+df_test.to_parquet("hf://datasets/username/my_dataset/test")
 ```
 
-This creates a dataset repository `username/my_dataset` containing your Dask dataset in Parquet format.
-You can reload it later:
+This will create a dataset repository `username/my_dataset` containing your data in Parquet format, which can be accessed later.
+
+## Reading Data from the Hub
+
+You can reload your dataset from the Hugging Face Hub just as easily:
 
 ```python
 import dask.dataframe as dd
 
+# Reading the entire dataset
 df = dd.read_parquet("hf://datasets/username/my_dataset")
 
-# or read from separate directories if the dataset has train/validation/test splits
+# Reading data from separate directories for train/validation/test splits
 df_train = dd.read_parquet("hf://datasets/username/my_dataset/train")
 df_valid = dd.read_parquet("hf://datasets/username/my_dataset/validation")
-df_test  = dd.read_parquet("hf://datasets/username/my_dataset/test")
+df_test = dd.read_parquet("hf://datasets/username/my_dataset/test")
 ```
 
-For more information on the Hugging Face paths and how they are implemented, please refer to the [the client library's documentation on the HfFileSystem](/docs/huggingface_hub/guides/hf_file_system).
+This allows you to seamlessly integrate your Dask workflows with datasets stored on the Hugging Face Hub.
+
+## Further Information
+
+For more detailed information on using Hugging Face paths and their implementation, refer to the [Hugging Face File System documentation](/docs/huggingface_hub/guides/hf_file_system).
+


### PR DESCRIPTION
This PR improves the documentation for integrating Dask with the Hugging Face Hub. The updates include:

- **Prerequisites and Setup:** Detailed instructions on how to authenticate and create a dataset repository before using Dask with Hugging Face paths.
- **Code Examples:** Clear examples for writing to and reading from the Hugging Face Hub using Dask's Parquet functionality.
- **References:** Added links to the Hugging Face File System documentation for users seeking more information.

These enhancements aim to make it easier for users to leverage Dask's distributed computing capabilities with datasets stored on the Hugging Face Hub.
